### PR TITLE
Allow passing custom sourceContent (e.g., coffee-script source) to inline-source-map.

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,8 @@ module.exports = function (opts) {
       else 
           generator.addGeneratedMappings(row.sourceFile, row.source, offset);
 
-      generator.addSourceContent(row.sourceFile, row.source);
+      var sourceContent = row.sourceContent ? row.sourceContent : row.source;
+      generator.addSourceContent(row.sourceFile, sourceContent);
     }
 
     function write (row) {


### PR DESCRIPTION
Currently browser-pack uses row.source as sourceContent, it works fine for javascript, but makes little sense for transpiled languages. In order to map the bundled code to the original source(e.g., coffee-script source), we need a way to pass it to inline-source-map.
