### PR TITLE
combining sourcemap comments found in the passed source into the bundle source map

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ var uglify = require('uglify-js');
 var fs = require('fs');
 var path = require('path');
 
-var createGenerator = require('inline-source-map');
+var combineSourceMap = require('combine-source-map');
 
 var prelude = (function () {
     var src = fs.readFileSync(path.join(__dirname, 'prelude.js'), 'utf8');
@@ -31,32 +31,23 @@ module.exports = function (opts) {
     var order = []; 
     
     var lineno = 1 + newlinesIn(prelude);
-    var generator;
+    var sourcemap;
 
     return duplexer(parser, output);
     
-    function addMappings(row) {
-      generator = generator || createGenerator({ sourceRoot: row.sourceRoot });
-      var offset = { line: lineno, column: 0 };
-
-      if (row.mappings && row.mappings.length)
-          generator.addMappings(row.sourceFile, row.mappings, offset);
-      else 
-          generator.addGeneratedMappings(row.sourceFile, row.source, offset);
-
-      generator.addSourceContent(row.sourceFile, row.source);
-    }
-
     function write (row) {
         if (first) this.queue(prelude);
         
-        if (row.sourceFile) addMappings(row);
+        if (row.sourceFile) { 
+            sourcemap = sourcemap || combineSourceMap.create();
+            sourcemap.addFile({ sourceFile: row.sourceFile, source: row.source }, { line: lineno });
+        }
 
-        wrappedSource = [
+        var wrappedSource = [
             (first ? '' : ','),
             JSON.stringify(row.id),
             ':[',
-            'function(require,module,exports){\n' + row.source + '\n}',
+            'function(require,module,exports){\n' + combineSourceMap.removeComments(row.source) + '\n}',
             ',',
             JSON.stringify(row.deps || {}),
             ']'
@@ -76,7 +67,7 @@ module.exports = function (opts) {
         if (first) this.queue(prelude);
         
         this.queue('},{},' + JSON.stringify(entries) + ')');
-        if (generator) this.queue('\n' + generator.inlineMappingUrl());
+        if (sourcemap) this.queue('\n' + sourcemap.comment());
 
         this.queue(null);
     }

--- a/package.json
+++ b/package.json
@@ -11,11 +11,14 @@
         "duplexer": "~0.0.3",
         "through": "~2.2.0",
         "uglify-js": "1.3.4",
-        "inline-source-map": "~0.2.1"
+        "combine-source-map": "~0.1.0"
+
     },
     "devDependencies": {
         "tap": "~0.4.0",
-        "tape": "~0.2.2"
+        "tape": "~0.2.2",
+        "convert-source-map": "~0.2.3",
+        "parse-base64vlq-mappings": "~0.1.1"
     },
     "scripts": {
         "test": "tap test/*.js"

--- a/test/source-maps-existing.js
+++ b/test/source-maps-existing.js
@@ -1,0 +1,56 @@
+var test = require('tape');
+var pack = require('../');
+var convert= require('convert-source-map');
+var parse = require('parse-base64vlq-mappings');
+
+var foo = { 
+    version: 3,
+    file: 'foo.js',
+    sourceRoot: '',
+    sources: [ 'foo.coffee' ],
+    names: [],
+    mappings: ';AAAA;CAAA;CAAA,CAAA,CAAA,IAAO,GAAK;CAAZ',
+    sourcesContent: [ 'console.log(require \'./bar.js\')\n' ] };
+
+test('pack one file with source file field and existing sourcemap', function (t) {
+    t.plan(7);
+    
+    var mapComment = convert.fromObject(foo).toComment();
+    var fooMappings = parse(foo.mappings);
+
+    var p = pack();
+    var src = '';
+    p.on('data', function (buf) { src += buf });
+    p.on('end', function () {
+
+        var sm = convert.fromSource(src).toObject();
+        var mappings = parse(sm.mappings);
+
+        var remainingMaps = src.match(convert.commentRegex);
+
+        var fstMap = mappings[0];
+        var fstFooMap = fooMappings[0];
+        var lstMap = mappings.pop();
+        var lstFooMap = fooMappings.pop();
+
+        t.deepEqual(fstMap.original, fstFooMap.original, 'first original mappings are same');
+        t.deepEqual(lstMap.original, lstFooMap.original, 'last original mappings are same');
+
+        t.equal(fstMap.generated.column, fstFooMap.generated.column, 'first generated columns are same');
+        t.equal(lstMap.generated.column, lstFooMap.generated.column, 'last generated columns are same');
+
+        t.equal(fstMap.generated.line, fstFooMap.generated.line + 1, 'first generated line is offset by 1');
+        t.equal(lstMap.generated.line, lstFooMap.generated.line + 1, 'last generated line is offset by 1');
+
+        t.equal(remainingMaps.length, 1, 'removes orinal source maps');
+    });
+    
+    p.end(JSON.stringify([
+        {
+            id: 'xyz',
+            source: '(function() {\n\n  console.log(require(\'./bar.js\'));\n\n}).call(this);\n' + '\n' + mapComment,
+            sourceFile: 'foo.js'
+        }
+    ]));
+});
+


### PR DESCRIPTION
Needed to make [this](http://thlorenz.github.com/WebGLCraft/) possible.
You can now see and debug original files if their generated source includes source maps, as is the case for the coffeeify transform.
