### PR TITLE
Move parent require finding to require runtime

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ var combineSourceMap = require('combine-source-map');
 
 var prelude = (function () {
     var src = fs.readFileSync(path.join(__dirname, 'prelude.js'), 'utf8');
-    return uglify(src) + '(typeof require!=="undefined"&&require,{';
+    return uglify(src) + '({';
 })();
 
 function newlinesIn(src) {

--- a/prelude.js
+++ b/prelude.js
@@ -7,22 +7,22 @@
 // anything defined in a previous bundle is accessed via the
 // orig method which is the requireuire for previous bundles
 
-(function(parent_req, modules, cache, entry) {
-    function require(name){
+(function(modules, cache, entry) {
+    function innerRequire(name){
         if(!cache[name]) {
             if(!modules[name]) {
                 // if we cannot find the item within our internal map revert to parent
-                if (parent_req) return parent_req(name);
+                if (typeof require === "function") return require(name);
                 throw new Error('Cannot find module \'' + name + '\'');
             }
             var m = cache[name] = {exports:{}};
             modules[name][0](function(x){
                 var id = modules[name][1][x];
-                return require(id ? id : x);
+                return innerRequire(id ? id : x);
             },m,m.exports);
         }
         return cache[name].exports
     }
-    for(var i=0;i<entry.length;i++) require(entry[i]);
-    return require;
+    for(var i=0;i<entry.length;i++) innerRequire(entry[i]);
+    return innerRequire;
 })


### PR DESCRIPTION
This makes browser bundles work that are added lazily.

Closes Browserify issue:
https://github.com/substack/node-browserify/issues/341

Browserify and browser-pack tests are all ok after this change.
