### PR TITLE
Jump to root require if module is not found from the local map

### DIFF
--- a/prelude.js
+++ b/prelude.js
@@ -8,21 +8,24 @@
 // orig method which is the requireuire for previous bundles
 
 (function(parent_req, modules, cache, entry) {
-    function require(name){
+    function inner_req(name, jumped){
         if(!cache[name]) {
             if(!modules[name]) {
-                // if we cannot find the item within our internal map revert to parent
+                // if we cannot find the item within our internal map jump to
+                // current root require go all requires down from there
+                var rootRequire = typeof require == "function" && require;
+                if (!jumped && rootRequire) return rootRequire(name, true);
                 if (parent_req) return parent_req(name);
                 throw new Error('Cannot find module \'' + name + '\'');
             }
             var m = cache[name] = {exports:{}};
             modules[name][0](function(x){
                 var id = modules[name][1][x];
-                return require(id ? id : x);
+                return inner_req(id ? id : x);
             },m,m.exports);
         }
         return cache[name].exports
     }
-    for(var i=0;i<entry.length;i++) require(entry[i]);
-    return require;
+    for(var i=0;i<entry.length;i++) inner_req(entry[i]);
+    return inner_req;
 })


### PR DESCRIPTION
Ok, another take on https://github.com/substack/node-browserify/issues/341

With this it shouldn't matter in which order multiple bundles are added
to the dom. If local require fails to find the module from its map it
jumps the to current root require in the global scope and works its way
back down from there.

Example usage https://github.com/epeli/lazy-browserify/blob/master/both.js
