### PR TITLE
`standalone` autoexecutes the entry module

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,6 +68,7 @@ module.exports = function (opts) {
         entries = entries.filter(function (x) { return x !== undefined });
         
         this.queue('},{},' + JSON.stringify(entries) + ')');
+        if(opts.standalone) this.queue('(' + entries[0] + ')');
         if (sourcemap) this.queue('\n' + sourcemap.comment());
 
         this.queue(null);


### PR DESCRIPTION
Hopefully half-fixes substack/node-browserify#430 (--debug and --standalone are broken when used together) by moving the auto-execution of the entry module from browserify to browser-pack.

Unfortunate, but no clean way to insert the autoexecution from browserify: the source map is emitted from within browserpack, and the auto-exec needs to be inserted between the end of browser-pack stuff and the source map.

Depends on a forthcoming PR in node-browserify.
