### PR TITLE
Fixes source maps for --require'd modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,13 +29,15 @@ module.exports = function (opts) {
     
     var lineno = 1 + newlinesIn(prelude);
     var sourcemap;
+    var seenSourceFiles = {};
     
     return stream;
     
     function write (row) {
         if (first) stream.queue((opts.prelude || prelude) + '({');
         
-        if (row.sourceFile) { 
+        if (row.sourceFile && !seenSourceFiles[row.sourceFile]) { 
+	    seenSourceFiles[row.sourceFile] = true;
             sourcemap = sourcemap || combineSourceMap.create();
             sourcemap.addFile(
                 { sourceFile: row.sourceFile, source: row.source },


### PR DESCRIPTION
This fixes https://github.com/substack/node-browserify/issues/465

Without it we replace the actual source with a stub.
