### PR TITLE
upgrading combine-source-map

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dependencies": {
         "JSONStream": "~0.6.4",
         "through": "~2.3.4",
-        "combine-source-map": "~0.1.1"
+        "combine-source-map": "~0.2.0"
 
     },
     "devDependencies": {


### PR DESCRIPTION
@ben-ng did some nice work to improve source-map parsing by using the `source-map` module that most others are using as well.
Not only is this more consistent, but also fixes some issues that the previous version had.

I also ran tests in [my browserify fork](https://github.com/thlorenz/node-browserify) which uses this newer version - remember to get this working we have to manually `npm install && npm run prepublish` in `browser-pack` since it gets installed from my github repo.

I also tested this together with es6ify to ensure that correct source maps are generated.

However I'd suggest to make this a `minor` upgrade and upgrade browser-pack in browserify which then should also see a `minor` upgrade -- just to be sure ;).
