### PR TITLE
add prelude file into sourcemap

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,8 +6,8 @@ var path = require('path');
 
 var combineSourceMap = require('combine-source-map');
 
-var defaultPrelude = fs.readFileSync(
-      path.join(__dirname, '_prelude.js'), 'utf8');
+var defaultPreludePath = path.join(__dirname, '_prelude.js');
+var defaultPrelude = fs.readFileSync(defaultPreludePath, 'utf8');
 
 function newlinesIn(src) {
   if (!src) return 0;
@@ -28,6 +28,7 @@ module.exports = function (opts) {
     var first = true;
     var entries = [];
     var prelude = opts.prelude || defaultPrelude;
+    var preludePath = opts.preludePath || defaultPreludePath;
     
     var lineno = 1 + newlinesIn(prelude);
     var sourcemap;
@@ -38,7 +39,11 @@ module.exports = function (opts) {
         if (first) stream.queue(prelude + '({');
         
         if (row.sourceFile && !row.nomap) {
-            sourcemap = sourcemap || combineSourceMap.create();
+            if (!sourcemap) {
+                sourcemap = combineSourceMap.create(),
+                { sourceFile: preludePath, source: prelude },
+                { line: 0 }
+            }
             sourcemap.addFile(
                 { sourceFile: row.sourceFile, source: row.source },
                 { line: lineno }

--- a/readme.markdown
+++ b/readme.markdown
@@ -67,7 +67,8 @@ determines the numeric index to execute the entries in.
 
 You can specify a custom prelude with `opts.prelude` but you should really know
 what you're doing first. See the `prelude.js` file in this repo for the default
-prelude.
+prelude. If you specify a custom prelude, you must also specify a valid
+`opts.preludePath` to the prelude source file for sourcemaps to work.
 
 # install
 


### PR DESCRIPTION
Without the prelude file map, errors within the prelude are harder to
track down. Also, when using the bundled sourcemap as input to tools
like Uglify, it causes remap errors when mappings cannot be found.
