### PR TITLE
Externalize dependencies with a UMD wrap using the standalone option

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,8 +41,14 @@ module.exports = function (opts) {
     
     function write (row, enc, next) {
         if (first && opts.standalone) {
-            var pre = umd.prelude(opts.standalone).trim();
-            stream.push(Buffer(pre + 'return '));
+            var pre;
+            var standalone = opts.standalone;
+            if (typeof standalone === 'string') {
+              pre = umd.prelude(standalone);
+            } else {
+              pre = umd.prelude(standalone.name, standalone.cjs, standalone);
+            }
+            stream.push(Buffer(pre.trim() + 'return '));
         }
         else if (first && stream.hasExports) {
             var pre = opts.externalRequireName || 'require';
@@ -95,11 +101,19 @@ module.exports = function (opts) {
         entries = entries.filter(function (x) { return x !== undefined });
         
         stream.push(Buffer('},{},' + JSON.stringify(entries) + ')'));
-        
+
         if (opts.standalone) {
+          var standaloneName;
+
+          if (typeof opts.standalone === 'string') {
+              standaloneName = opts.standalone;
+            } else {
+              standaloneName = opts.standalone.name;
+            }
+
             stream.push(Buffer(
                 '(' + JSON.stringify(stream.standaloneModule) + ')'
-                + umd.postlude(opts.standalone)
+                + umd.postlude(standaloneName)
             ));
         }
         

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "combine-source-map": "~0.3.0",
     "concat-stream": "~1.4.1",
     "through2": "~0.5.1",
-    "umd": "^2.1.0"
+    "umd": "cmaher/umd"
   },
   "devDependencies": {
     "tap": "~0.4.0",


### PR DESCRIPTION
DEPENDENCY: https://github.com/ForbesLindesay/umd/pull/19

This adds the ability to externalize dependencies using the standalone option

``` js
  var bundleStream = browserify('./index.js', {
      standalone: {
        name: 'my-module',
        amd: { deps: ['underscore'] }
      }
    })
    .exclude('underscore')
    .bundle();
```

Note that I am unaware of how active https://github.com/ForbesLindesay/umd is, nor can I guarantee how that PR will go. That said, I think this is an important behavior with the possibility to resolve some browserify issues.
