### PR TITLE
Add missing semi-colon when using source maps

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,7 +109,7 @@ module.exports = function (opts) {
                     /^\/\/#/, function () { return opts.sourceMapPrefix }
                 )
             }
-            stream.push(Buffer('\n' + comment + '\n'));
+            stream.push(Buffer(';\n' + comment + '\n'));
         }
         if (!sourcemap && !opts.standalone) stream.push(Buffer(';\n'));
 


### PR DESCRIPTION
When minifying and concatenating files the missing trailing semi-colon can create side effects resulting in bugs.
