### PR TITLE
Relative default prelude path in source maps

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 var JSONStream = require('JSONStream');
+var defined = require('defined');
 var through = require('through2');
 var umd = require('umd');
 
@@ -30,8 +31,9 @@ module.exports = function (opts) {
     
     var first = true;
     var entries = [];
+    var basedir = defined(opts.basedir, process.cwd());
     var prelude = opts.prelude || defaultPrelude;
-    var preludePath = opts.preludePath || defaultPreludePath;
+    var preludePath = opts.preludePath || path.relative(basedir, defaultPreludePath);
     
     var lineno = 1 + newlinesIn(prelude);
     var sourcemap;

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "JSONStream": "~0.8.4",
     "combine-source-map": "~0.3.0",
     "concat-stream": "~1.4.1",
+    "defined": "~0.0.0",
     "through2": "~0.5.1",
     "umd": "^2.1.0"
   },


### PR DESCRIPTION
The extra path info adds noise when debugging and makes debug builds non-deterministic. See https://github.com/substack/node-browserify/pull/923
