### PR TITLE
Add `name` to require call arguments.

### DIFF
--- a/prelude.js
+++ b/prelude.js
@@ -33,7 +33,7 @@
             modules[name][0].call(m.exports, function(x){
                 var id = modules[name][1][x];
                 return newRequire(id ? id : x);
-            },m,m.exports,outer,modules,cache,entry);
+            },m,m.exports,outer,modules,cache,entry,name);
         }
         return cache[name].exports;
     }


### PR DESCRIPTION
This allows you to identify the id of the current file, in turn accessing that file's cached require values. This makes it possible, with a few extra steps, to override or ignore the require cache from browserify.
