### PR TITLE
adding ability to define source map root

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ module.exports = function (opts) {
         
         if (row.sourceFile && !row.nomap) {
             if (!sourcemap) {
-                sourcemap = combineSourceMap.create();
+                sourcemap = combineSourceMap.create(null, opts.sourceRoot);
                 sourcemap.addFile(
                     { sourceFile: preludePath, source: prelude },
                     { line: 0 }

--- a/readme.markdown
+++ b/readme.markdown
@@ -62,6 +62,9 @@ written to it instead of expecting a stream of json text it will need to parse.
 If `opts.sourceMapPrefix` is given and source maps are computed, the
 `opts.sourceMapPrefix` string will be used instead of `//#`.
 
+If `opts.sourceRoot` is given and source maps are computed, the root for the
+output source map will be defined. (default is no root)
+
 Additionally, rows with a truthy `entry` may have an `order` field that
 determines the numeric index to execute the entries in.
 

--- a/test/source-maps.js
+++ b/test/source-maps.js
@@ -193,3 +193,29 @@ test('custom sourceMapPrefix for //@', function (t) {
     ]));
 });
 
+test('custom sourceRoot', function (t) {
+  t.plan(1);
+
+  var p = pack({ sourceRoot: '/custom-root' });
+  var src = '';
+  p.on('data', function (buf) { src += buf });
+  p.on('end', function () {
+      var lastLine = grabLastLine(src);
+      var sm = grabSourceMap(lastLine);
+      t.equal(sm.sourceRoot, '/custom-root', 'sets a custom source root' );
+  });
+
+  p.end(JSON.stringify([
+      {
+          id: 'abc',
+          source: 'T.equal(require("./xyz")(3), 333)',
+          entry: true,
+          deps: { './xyz': 'xyz' }
+      },
+      {
+          id: 'xyz',
+          source: 'T.ok(true);\nmodule.exports=function(n){\n return n*111 \n}',
+          sourceFile: 'foo.js'
+      }
+  ]));
+});


### PR DESCRIPTION
I'm using this in a build tool I'm working on, being able to set the source map root is actually a feature I wanted to have. It's a pretty straightforward change, but let me know if there is anything else you'd like me to do.
