### PR TITLE
Update combine-source-map, fixes #77

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "JSONStream": "^1.0.3",
-    "combine-source-map": "~0.7.1",
+    "combine-source-map": "~0.8.0",
     "defined": "^1.0.0",
     "through2": "^2.0.0",
     "umd": "^3.0.0"


### PR DESCRIPTION
Fixes some issues where it could output paths with backslashes on Windows.