### PR TITLE
Update tap

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "umd": "^3.0.0"
   },
   "devDependencies": {
-    "tap": "^2.2.0",
+    "tap": "^10.7.2",
     "uglify-js": "1.3.5",
     "concat-stream": "~1.5.1",
     "convert-source-map": "~1.1.0",


### PR DESCRIPTION
Fixes deprecation warnings during tests:

    Warning: process.on(SIGPROF) is reserved while debugging